### PR TITLE
fix(profile): remove U-Pro Gold when adding or updating children

### DIFF
--- a/src/components/parent/ChildProfileForm.tsx
+++ b/src/components/parent/ChildProfileForm.tsx
@@ -43,7 +43,6 @@ export function ChildProfileForm({
     dominant_foot: initialData?.dominant_foot,
     playing_position: initialData?.playing_position || "",
     experience_total: initialData?.experience_total || 0,
-    upro_gold: initialData?.upro_gold || 0,
     profile_picture: initialData?.profile_picture || "",
   });
 
@@ -278,24 +277,6 @@ export function ChildProfileForm({
               />
             </div>
 
-            {/* Upro Gold */}
-            <div className="space-y-2">
-              <Label htmlFor="upro_gold">Upro Gold</Label>
-              <Input
-                id="upro_gold"
-                type="number"
-                min="0"
-                step="1"
-                value={formData.upro_gold || ""}
-                onChange={e =>
-                  updateFormData(
-                    "upro_gold",
-                    e.target.value ? parseInt(e.target.value) : 0
-                  )
-                }
-                className="w-full"
-              />
-            </div>
 
             {/* Profile Picture */}
             <div className="space-y-2">

--- a/src/types/parent-dashboard.ts
+++ b/src/types/parent-dashboard.ts
@@ -36,7 +36,6 @@ export interface CreateChildProfileData {
   dominant_foot?: boolean;
   playing_position?: string;
   experience_total?: number;
-  upro_gold?: number;
   profile_picture?: string;
 }
 


### PR DESCRIPTION
### ✅ **What to Include**

- ✅ **Title** – Remove the U-Pro Gold Input in the profile page
- ✅ **Description** - U-Pro should not be edited by users.
- ✅ **Screenshots/Demo** – Add screenshots, videos, or Looms if visual

### Discord Name:

<!-- paracide (Arthur) --->


### 📎 **Related Issues**

<!-- Link issues like: https://github.com/BuildersLeague/upro-web/issues/39 Closes #39 -->
